### PR TITLE
PR: Grouping successful notifications by test suites

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "eslint-formatter-json-std",
+	"name": "mocha-reporter-json-standard",
 	"version": "1.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
@@ -140,6 +140,21 @@
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
 			"integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
 			"dev": true
+		},
+		"@types/lodash": {
+			"version": "4.14.172",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.172.tgz",
+			"integrity": "sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw==",
+			"dev": true
+		},
+		"@types/lodash.groupby": {
+			"version": "4.6.6",
+			"resolved": "https://registry.npmjs.org/@types/lodash.groupby/-/lodash.groupby-4.6.6.tgz",
+			"integrity": "sha512-kwg3T7Ia63KtDNoQQR8hKrLHCAgrH4I44l5uEMuA6JCbj7DiSccaV4tNV1vbjtAOpX990SolVthJCmBVtRVRgw==",
+			"dev": true,
+			"requires": {
+				"@types/lodash": "*"
+			}
 		},
 		"@types/minimatch": {
 			"version": "3.0.3",
@@ -2265,6 +2280,12 @@
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
 			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+			"dev": true
+		},
+		"lodash.groupby": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+			"integrity": "sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E=",
 			"dev": true
 		},
 		"lodash.zip": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 	"devDependencies": {
 		"@hutsoninc/flatten-dir-cli": "^1.0.2",
 		"@types/eslint": "^7.2.0",
+		"@types/lodash.groupby": "^4.6.6",
 		"@types/mocha": "7.0.2",
 		"@types/node": "14.0.13",
 		"@types/source-map-support": "^0.5.1",
@@ -44,9 +45,9 @@
 		"eslint": "^7.3.1",
 		"eslint-plugin-fp": "2.3.0",
 		"json-schema-to-typescript": "^9.1.0",
+		"lodash.groupby": "^4.6.0",
 		"mocha": "8.0.1",
 		"source-map-support": "^0.5.19",
 		"typescript": "3.9.3"
-	},
-	"dependencies": {}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
 	"devDependencies": {
 		"@hutsoninc/flatten-dir-cli": "^1.0.2",
 		"@types/eslint": "^7.2.0",
-		"@types/lodash.groupby": "^4.6.6",
 		"@types/mocha": "7.0.2",
 		"@types/node": "14.0.13",
 		"@types/source-map-support": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
 		"eslint": "^7.3.1",
 		"eslint-plugin-fp": "2.3.0",
 		"json-schema-to-typescript": "^9.1.0",
-		"lodash.groupby": "^4.6.0",
 		"mocha": "8.0.1",
 		"source-map-support": "^0.5.19",
 		"typescript": "3.9.3"

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ module.exports = function (this: unknown, runner: Runner) {
 				...succesfullSuiteNames.map((sName, i) => ({
 					Id: `success-${i}`,
 					title: sName,
-					message: `${rootSuites[sName].length} tests passed: ${rootSuites[sName].map(t => t.title).join(", ")}`,
+					message: `${rootSuites[sName].length} tests passed: ${rootSuites[sName].map(t => t.title).join(" / ")}`,
 					category: "notice" as CheckGeneralSchema["byFile"]["details"]["details"][0]["category"]
 				})),
 				...individualFailures.map((f, i) => ({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,9 @@
 /* eslint-disable fp/no-mutating-methods */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable fp/no-mutation */
-import { default as groupBy } from "lodash.groupby"
 
 import { Runner, reporters, Test, Suite } from 'mocha'
 import { CheckGeneralSchema } from "./check-general"
-
-interface TestFailure {
-	"stack": string;
-	"message": string,
-	"generatedMessage": boolean,
-	"name": string,
-	"code": string,
-	"actual": string, //json
-	"expected": string, //json
-	"operator": string
-}
 
 module.exports = function (this: unknown, runner: Runner) {
 	const {
@@ -60,13 +48,14 @@ module.exports = function (this: unknown, runner: Runner) {
 		const individualFailures = individualTests.filter(t => t.state !== "passed")
 		results.counts.failure = individualFailures.length
 		results.byFile["General"] = {
+			summary: "",
 			counts: { failure: individualFailures.length, warning: 0, notice: 0 },
 			details: [
 				...succesfullSuiteNames.map((sName, i) => ({
 					Id: `success-${i}`,
 					title: sName,
 					message: `${rootSuites[sName].length} tests passed`,
-					category: "passed" as CheckGeneralSchema["byFile"]["details"]["details"][0]["category"]
+					category: "notice" as CheckGeneralSchema["byFile"]["details"]["details"][0]["category"]
 				})),
 				...individualFailures.map((f, i) => ({
 					Id: `failure-${i}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ module.exports = function (this: unknown, runner: Runner) {
 				...succesfullSuiteNames.map((sName, i) => ({
 					Id: `success-${i}`,
 					title: sName,
-					message: `${rootSuites[sName].length} tests passed`,
+					message: `${rootSuites[sName].length} tests passed: ${rootSuites[sName].map(t => t.title).join(", ")}`,
 					category: "notice" as CheckGeneralSchema["byFile"]["details"]["details"][0]["category"]
 				})),
 				...individualFailures.map((f, i) => ({

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@ module.exports = function (this: unknown, runner: Runner) {
 	} = Runner.constants
 	reporters.Base.call(this, runner)
 
-	/** Corresponds to a top-most describe block */
 	const individualTests: Test[] = []
 	const rootSuites: { [key: string]: Test[] } = {}
 


### PR DESCRIPTION
Resolves #5 

**Merge message:**
Formatted the script output to group all successful tests of a suite in a single entry of the "details" array, creating individual entries only for failing tests.